### PR TITLE
[WiP] PHP7 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: php
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 php:
     - 5.3
@@ -32,8 +37,8 @@ matrix:
 
 before_script:
   - composer self-update -q
-  - if [ -z "$dependencies" ]; then composer install; fi;
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
-  - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
+  - if [ -z "$dependencies" ]; then composer install --prefer-dist; fi;
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --prefer-dist -n; fi;
+  - if [ "$dependencies" = "highest" ]; then composer update --prefer-dist -n; fi;
 
 script: phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ php:
 
 matrix:
   include:
+    - php: 5.3
+      env: dependencies=lowest
+    - php: 5.4
+      env: dependencies=lowest
+    - php: 5.5
+      env: dependencies=lowest
     - php: 5.6
       env: dependencies=lowest
     - php: 7
@@ -18,6 +24,9 @@ matrix:
       env: dependencies=highest
     - php: 7
       env: dependencies=highest
+  exclude:
+    - php: 5.3
+    - php: 5.4
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,27 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7
     - hhvm
 
-before_script:
-  - composer self-update
-  - composer install --dev
-
-script: phpunit
-
 matrix:
+  include:
+    - php: 5.6
+      env: dependencies=lowest
+    - php: 7
+      env: dependencies=lowest
+    - php: 5.6
+      env: dependencies=highest
+    - php: 7
+      env: dependencies=highest
   allow_failures:
     - php: hhvm
+
+before_script:
+  - composer self-update -q
+  - if [ -z "$dependencies" ]; then composer install; fi;
+  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest -n; fi;
+  - if [ "$dependencies" = "highest" ]; then composer update -n; fi;
+
+script: phpunit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+## vX
+
+This version's changes are mostly in order to make this library PHP 7 compatible.
+
+BC:
+- Int, Float and Boolean filters and annotations get `Scalar` suffix to not clash with reserved words
+
+Internal:
+- The use of `self` in `RegExp` filter was returning the original value not the new updated one, this seems to be a change in PHP, so we now use `static` which makes it more friendly to extensions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
-## vX
+# Changelog
 
-This version's changes are mostly in order to make this library PHP 7 compatible.
+From v3.0.0 onwards this file will always be updated with notable changes and BC breaks.
+This project follows semver.
 
-BC:
+## [3.0.0] - 2016-02-28
+### Changed
 - Int, Float and Boolean filters and annotations get `Scalar` suffix to not clash with reserved words
 
-Internal:
+### Fixed
 - The use of `self` in `RegExp` filter was returning the original value not the new updated one, this seems to be a change in PHP, so we now use `static` which makes it more friendly to extensions.

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "phpunit/phpunit": "~3.7",
         "doctrine/cache": "~1.3",
-        "zendframework/zend-filter": "~2.0"
+        "zendframework/zend-filter": "^2.0.3"
     },
 
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
 
     "require": {
-        "php":  ">=5.3.2",
+        "php":  "^5.3.2 || ^7.0",
         "doctrine/annotations": "~1.1"
     },
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "2634bb0d87ea9e9aee7948a3f71e5292",
-    "content-hash": "066877b2db70251fcd9971dc9c4339f8",
+    "hash": "abb987eb72310f03b2ce5ea363edc099",
+    "content-hash": "e236739287e67bb687329a15f8b806bb",
     "packages": [
         {
             "name": "doctrine/annotations",

--- a/composer.lock
+++ b/composer.lock
@@ -1,22 +1,24 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
-    "hash": "b59fba71a7be12c98baa9f68828f0034",
+    "hash": "2634bb0d87ea9e9aee7948a3f71e5292",
+    "content-hash": "066877b2db70251fcd9971dc9c4339f8",
     "packages": [
         {
             "name": "doctrine/annotations",
-            "version": "v1.1.2",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/annotations.git",
-                "reference": "40db0c96985aab2822edbc4848b3bd2429e02670"
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/40db0c96985aab2822edbc4848b3bd2429e02670",
-                "reference": "40db0c96985aab2822edbc4848b3bd2429e02670",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
+                "reference": "f25c8aab83e0c3e976fd7d19875f198ccf2f7535",
                 "shasum": ""
             },
             "require": {
@@ -24,12 +26,13 @@
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "doctrine/cache": "1.*"
+                "doctrine/cache": "1.*",
+                "phpunit/phpunit": "4.*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.3.x-dev"
                 }
             },
             "autoload": {
@@ -43,17 +46,6 @@
             ],
             "authors": [
                 {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com",
-                    "homepage": "http://www.jwage.com/",
-                    "role": "Creator"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com",
-                    "homepage": "http://www.instaclick.com"
-                },
-                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
@@ -62,10 +54,16 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "http://jmsyst.com",
-                    "role": "Developer of wrapped JMSSerializerBundle"
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
             "description": "Docblock Annotations Parser",
@@ -75,26 +73,31 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2013-06-16 21:33:03"
+            "time": "2015-08-31 12:32:49"
         },
         {
             "name": "doctrine/lexer",
-            "version": "v1.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/lexer.git",
-                "reference": "2f708a85bb3aab5d99dab8be435abd73e0b18acb"
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/2f708a85bb3aab5d99dab8be435abd73e0b18acb",
-                "reference": "2f708a85bb3aab5d99dab8be435abd73e0b18acb",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/83893c552fd2045dd78aef794c31e694c37c0b8c",
+                "reference": "83893c552fd2045dd78aef794c31e694c37c0b8c",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "Doctrine\\Common\\Lexer\\": "lib/"
@@ -106,19 +109,16 @@
             ],
             "authors": [
                 {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com",
-                    "homepage": "http://www.instaclick.com"
-                },
-                {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
                 },
                 {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
                     "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "http://jmsyst.com",
-                    "role": "Developer of wrapped JMSSerializerBundle"
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
             "description": "Base library for a lexer that can be used in Top-Down, Recursive Descent Parsers.",
@@ -127,43 +127,44 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2013-01-12 18:59:04"
+            "time": "2014-09-09 13:34:57"
         }
     ],
     "packages-dev": [
         {
             "name": "doctrine/cache",
-            "version": "v1.3.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "e16d7adf45664a50fa86f515b6d5e7f670130449"
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/e16d7adf45664a50fa86f515b6d5e7f670130449",
-                "reference": "e16d7adf45664a50fa86f515b6d5e7f670130449",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": "~5.5|~7.0"
             },
             "conflict": {
                 "doctrine/common": ">2.2,<2.4"
             },
             "require-dev": {
-                "phpunit/phpunit": ">=3.7",
+                "phpunit/phpunit": "~4.8|~5.0",
+                "predis/predis": "~1.0",
                 "satooshi/php-coveralls": "~0.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Doctrine\\Common\\Cache\\": "lib/"
+                "psr-4": {
+                    "Doctrine\\Common\\Cache\\": "lib/Doctrine/Common/Cache"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -171,17 +172,6 @@
                 "MIT"
             ],
             "authors": [
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com",
-                    "homepage": "http://www.jwage.com/",
-                    "role": "Creator"
-                },
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com",
-                    "homepage": "http://www.instaclick.com"
-                },
                 {
                     "name": "Roman Borschel",
                     "email": "roman@code-factory.org"
@@ -191,10 +181,16 @@
                     "email": "kontakt@beberlei.de"
                 },
                 {
-                    "name": "Johannes M. Schmitt",
-                    "email": "schmittjoh@gmail.com",
-                    "homepage": "http://jmsyst.com",
-                    "role": "Developer of wrapped JMSSerializerBundle"
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
                 }
             ],
             "description": "Caching library offering an object-oriented API for many cache backends",
@@ -203,27 +199,27 @@
                 "cache",
                 "caching"
             ],
-            "time": "2013-10-25 19:04:14"
+            "time": "2015-12-31 16:37:02"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "1.2.13",
+            "version": "1.2.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "466e7cd2554b4e264c9e3f31216d25ac0e5f3d94"
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/466e7cd2554b4e264c9e3f31216d25ac0e5f3d94",
-                "reference": "466e7cd2554b4e264c9e3f31216d25ac0e5f3d94",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
+                "reference": "fe2466802556d3fe4e4d1d58ffd3ccfd0a19be0b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3",
                 "phpunit/php-file-iterator": ">=1.3.0@stable",
-                "phpunit/php-text-template": ">=1.1.1@stable",
-                "phpunit/php-token-stream": ">=1.1.3@stable"
+                "phpunit/php-text-template": ">=1.2.0@stable",
+                "phpunit/php-token-stream": ">=1.1.3,<1.3.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "3.7.*@dev"
@@ -264,35 +260,37 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2013-09-10 08:14:32"
+            "time": "2014-09-02 10:13:14"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.3.4",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb"
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/acd690379117b042d1c8af1fafd61bde001bf6bb",
-                "reference": "acd690379117b042d1c8af1fafd61bde001bf6bb",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
-                    "File/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -309,20 +307,20 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2013-10-10 15:34:57"
+            "time": "2015-06-21 13:08:43"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "1.1.4",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5180896f51c5b3648ac946b05f9ec02be78a0b23"
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5180896f51c5b3648ac946b05f9ec02be78a0b23",
-                "reference": "5180896f51c5b3648ac946b05f9ec02be78a0b23",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
                 "shasum": ""
             },
             "require": {
@@ -331,20 +329,17 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "Text/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -353,20 +348,20 @@
             "keywords": [
                 "template"
             ],
-            "time": "2012-10-31 18:15:28"
+            "time": "2015-06-21 13:50:34"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.5",
+            "version": "1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c"
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
-                "reference": "19689d4354b295ee3d8c54b4f42c3efb69cbc17c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
                 "shasum": ""
             },
             "require": {
@@ -375,13 +370,10 @@
             "type": "library",
             "autoload": {
                 "classmap": [
-                    "PHP/"
+                    "src/"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                ""
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -397,20 +389,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2013-08-02 07:42:54"
+            "time": "2015-06-21 08:01:12"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e"
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
-                "reference": "5220af2a7929aa35cf663d97c89ad3d50cf5fa3e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/ad4e1e23ae01b483c16f600ff1bebec184588e32",
+                "reference": "ad4e1e23ae01b483c16f600ff1bebec184588e32",
                 "shasum": ""
             },
             "require": {
@@ -447,43 +439,42 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2013-09-13 04:58:23"
+            "time": "2014-03-03 05:10:30"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "3.7.29",
+            "version": "3.7.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "faeb2d9f15dc83830d2db5e4c67acf1d68c9b5ac"
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/faeb2d9f15dc83830d2db5e4c67acf1d68c9b5ac",
-                "reference": "faeb2d9f15dc83830d2db5e4c67acf1d68c9b5ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/38709dc22d519a3d1be46849868aa2ddf822bcf6",
+                "reference": "38709dc22d519a3d1be46849868aa2ddf822bcf6",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
                 "ext-dom": "*",
+                "ext-json": "*",
                 "ext-pcre": "*",
                 "ext-reflection": "*",
                 "ext-spl": "*",
                 "php": ">=5.3.3",
-                "phpunit/php-code-coverage": "~1.2.1",
-                "phpunit/php-file-iterator": ">=1.3.1",
-                "phpunit/php-text-template": ">=1.1.1",
-                "phpunit/php-timer": ">=1.0.4",
-                "phpunit/phpunit-mock-objects": "~1.2.0",
+                "phpunit/php-code-coverage": "~1.2",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.1",
+                "phpunit/php-timer": "~1.0",
+                "phpunit/phpunit-mock-objects": "~1.2",
                 "symfony/yaml": "~2.0"
             },
             "require-dev": {
-                "pear-pear/pear": "1.9.4"
+                "pear-pear.php.net/pear": "1.9.4"
             },
             "suggest": {
-                "ext-json": "*",
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "phpunit/php-invoker": ">=1.1.0,<1.2.0"
+                "phpunit/php-invoker": "~1.1"
             },
             "bin": [
                 "composer/bin/phpunit"
@@ -521,7 +512,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2014-01-15 06:46:38"
+            "time": "2014-10-17 09:04:17"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -574,32 +565,34 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v2.4.1",
-            "target-dir": "Symfony/Component/Yaml",
+            "version": "v2.8.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/Yaml.git",
-                "reference": "4e1a237fc48145fae114b96458d799746ad89aa0"
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "34c8a4b51e751e7ea869b8262f883d008a2b81b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/Yaml/zipball/4e1a237fc48145fae114b96458d799746ad89aa0",
-                "reference": "4e1a237fc48145fae114b96458d799746ad89aa0",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/34c8a4b51e751e7ea869b8262f883d008a2b81b8",
+                "reference": "34c8a4b51e751e7ea869b8262f883d008a2b81b8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.3.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
+                "psr-4": {
                     "Symfony\\Component\\Yaml\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -612,126 +605,132 @@
                 },
                 {
                     "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony Yaml Component",
-            "homepage": "http://symfony.com",
-            "time": "2013-12-28 08:12:03"
+            "homepage": "https://symfony.com",
+            "time": "2016-01-13 10:28:07"
         },
         {
             "name": "zendframework/zend-filter",
-            "version": "2.2.5",
-            "target-dir": "Zend/Filter",
+            "version": "2.6.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/Component_ZendFilter.git",
-                "reference": "0dbe1c10822a340a253a99147bb004978915f641"
+                "url": "https://github.com/zendframework/zend-filter.git",
+                "reference": "81078bee5529cfd7444c262b658e9f276b8f7af2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://packages.zendframework.com/composer/zendframework-zend-filter-0dbe1c10822a340a253a99147bb004978915f641-zip-8a2bc1.zip",
-                "reference": "2.2.5",
-                "shasum": "ba078a81b2b0e194eb3bc27eb2b791ccc00eb6b7"
+                "url": "https://packages.zendframework.com/composer/zendframework-zend-filter-2.6.1-bace94.zip",
+                "reference": "81078bee5529cfd7444c262b658e9f276b8f7af2",
+                "shasum": "d7a5a8264d158a6f472b2264dca363cdee7b652f"
             },
             "require": {
-                "php": ">=5.3.3",
-                "zendframework/zend-stdlib": "self.version"
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "zendframework/zend-crypt": "self.version"
+                "fabpot/php-cs-fixer": "1.7.*",
+                "pear/archive_tar": "^1.4",
+                "phpunit/phpunit": "~4.0",
+                "zendframework/zend-crypt": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
-                "zendframework/zend-crypt": "Zend\\Crypt component",
-                "zendframework/zend-i18n": "Zend\\I18n component",
-                "zendframework/zend-stdlib": "Zend\\Stdlib component",
-                "zendframework/zend-uri": "Zend\\Uri component for UriNormalize filter",
-                "zendframework/zend-validator": "Zend\\Validator component"
+                "zendframework/zend-crypt": "Zend\\Crypt component, for encryption filters",
+                "zendframework/zend-i18n": "Zend\\I18n component for filters depending on i18n functionality",
+                "zendframework/zend-servicemanager": "Zend\\ServiceManager component, for using the filter chain functionality",
+                "zendframework/zend-uri": "Zend\\Uri component, for the UriNormalize filter"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "2.6-dev",
+                    "dev-develop": "2.7-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Zend\\Filter\\": ""
+                "psr-4": {
+                    "Zend\\Filter\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Filter\\": "test/"
                 }
             },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": "provides a set of commonly needed data filters",
+            "homepage": "https://github.com/zendframework/zend-filter",
             "keywords": [
                 "filter",
                 "zf2"
             ],
-            "support": {
-                "source": "https://github.com/zendframework/Component_ZendFilter/tree/release-2.2.5"
-            },
-            "time": "2013-10-20 06:00:14"
+            "time": "2016-02-08 18:02:37"
         },
         {
             "name": "zendframework/zend-stdlib",
-            "version": "2.2.5",
-            "target-dir": "Zend/Stdlib",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/zendframework/Component_ZendStdlib.git",
-                "reference": "f440ecfc828d61d620662a03987c8287e1e4801e"
+                "url": "https://github.com/zendframework/zend-stdlib.git",
+                "reference": "86682d6607fe914577dab5388b95ef51ae18aa06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://packages.zendframework.com/composer/zendframework-zend-stdlib-f440ecfc828d61d620662a03987c8287e1e4801e-zip-7e3c9b.zip",
-                "reference": "2.2.5",
-                "shasum": "d142b30e831141bcf5ed77e0d3ebd9356afcf9ce"
+                "url": "https://packages.zendframework.com/composer/zendframework-zend-stdlib-3.0.0-7f518e.zip",
+                "reference": "86682d6607fe914577dab5388b95ef51ae18aa06",
+                "shasum": "c813780712e2f3dc4cd28995c9c2b05a519de5c3"
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.5 || ^7.0"
             },
-            "suggest": {
-                "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
-                "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+            "require-dev": {
+                "athletic/athletic": "~0.1",
+                "fabpot/php-cs-fixer": "1.7.*",
+                "phpunit/phpunit": "~4.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev",
-                    "dev-develop": "2.3-dev"
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Zend\\Stdlib\\": ""
+                "psr-4": {
+                    "Zend\\Stdlib\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "ZendTest\\Stdlib\\": "test/",
+                    "ZendBench\\Stdlib\\": "benchmark/"
                 }
             },
             "license": [
                 "BSD-3-Clause"
             ],
             "description": " ",
+            "homepage": "https://github.com/zendframework/zend-stdlib",
             "keywords": [
                 "stdlib",
                 "zf2"
             ],
-            "support": {
-                "source": "https://github.com/zendframework/Component_ZendStdlib/tree/release-2.2.5"
-            },
-            "time": "2013-10-20 06:00:20"
+            "time": "2016-02-03 16:53:37"
         }
     ],
-    "aliases": [
-
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [
-
-    ],
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": "^5.3.2 || ^7.0"
     },
-    "platform-dev": [
-
-    ]
+    "platform-dev": []
 }

--- a/src/DMS/Filter/Exception/FilterException.php
+++ b/src/DMS/Filter/Exception/FilterException.php
@@ -4,12 +4,11 @@ namespace DMS\Filter\Exception;
 
 /**
  * Base Exception for Filter Package
- * 
+ *
  * @package DMS
  * @subpackage Filter
  * @category Exception
  */
 class FilterException extends \RuntimeException
 {
-    
 }

--- a/src/DMS/Filter/Exception/InvalidCallbackException.php
+++ b/src/DMS/Filter/Exception/InvalidCallbackException.php
@@ -4,5 +4,4 @@ namespace DMS\Filter\Exception;
 
 class InvalidCallbackException extends FilterException
 {
-
 }

--- a/src/DMS/Filter/Exception/InvalidOptionsException.php
+++ b/src/DMS/Filter/Exception/InvalidOptionsException.php
@@ -4,13 +4,11 @@ namespace DMS\Filter\Exception;
 
 /**
  * Invalid option passed to rule
- * 
+ *
  * @package DMS
  * @subpackage Filter
  * @category Exception
  */
 class InvalidOptionsException extends RuleOptionsException
 {
-      
 }
-

--- a/src/DMS/Filter/Exception/InvalidZendFilterException.php
+++ b/src/DMS/Filter/Exception/InvalidZendFilterException.php
@@ -4,5 +4,4 @@ namespace DMS\Filter\Exception;
 
 class InvalidZendFilterException extends FilterException
 {
-
 }

--- a/src/DMS/Filter/Exception/MissingOptionsException.php
+++ b/src/DMS/Filter/Exception/MissingOptionsException.php
@@ -4,12 +4,11 @@ namespace DMS\Filter\Exception;
 
 /**
  * Required options were not passed to rule
- * 
+ *
  * @package DMS
  * @subpackage Filter
  * @category Exception
  */
 class MissingOptionsException extends RuleOptionsException
 {
-    
 }

--- a/src/DMS/Filter/Exception/RuleDefinitionException.php
+++ b/src/DMS/Filter/Exception/RuleDefinitionException.php
@@ -4,13 +4,11 @@ namespace DMS\Filter\Exception;
 
 /**
  * Malformed Rule definition
- * 
+ *
  * @package DMS
  * @subpackage Filter
  * @category Exception
  */
 class RuleDefinitionException extends FilterException
 {
-    
 }
-

--- a/src/DMS/Filter/Exception/RuleOptionsException.php
+++ b/src/DMS/Filter/Exception/RuleOptionsException.php
@@ -39,4 +39,3 @@ class RuleOptionsException extends FilterException
         return $this->options;
     }
 }
-

--- a/src/DMS/Filter/Filter.php
+++ b/src/DMS/Filter/Filter.php
@@ -65,7 +65,6 @@ class Filter implements FilterInterface
      */
     public function filterValue($value, $rule)
     {
-
         if ($rule instanceof Rules\Rule) {
             $filter = $this->filterLoader->getFilterForRule($rule);
             return $filter->apply($rule, $value);
@@ -105,11 +104,8 @@ class Filter implements FilterInterface
 
         //Iterate over properties with filters
         foreach ($properties as $property) {
-
             $walker->applyFilterRules($property, $metadata->getPropertyRules($property));
-
         }
-
     }
 
     /**
@@ -128,5 +124,4 @@ class Filter implements FilterInterface
 
         return $value;
     }
-
 }

--- a/src/DMS/Filter/FilterInterface.php
+++ b/src/DMS/Filter/FilterInterface.php
@@ -43,5 +43,4 @@ interface FilterInterface
      * @return Mapping\ClassMetadataFactoryInterface
      */
     public function getMetadataFactory();
-
 }

--- a/src/DMS/Filter/Filters/BaseFilter.php
+++ b/src/DMS/Filter/Filters/BaseFilter.php
@@ -24,6 +24,5 @@ abstract class BaseFilter
      *
      * @return mixed
      */
-    abstract function apply(Rule $rule, $value);
-
+    abstract public function apply(Rule $rule, $value);
 }

--- a/src/DMS/Filter/Filters/BooleanScalar.php
+++ b/src/DMS/Filter/Filters/BooleanScalar.php
@@ -19,5 +19,4 @@ class BooleanScalar extends BaseFilter
     {
         return (boolean) $value;
     }
-
 }

--- a/src/DMS/Filter/Filters/BooleanScalar.php
+++ b/src/DMS/Filter/Filters/BooleanScalar.php
@@ -5,12 +5,12 @@ namespace DMS\Filter\Filters;
 use DMS\Filter\Rules\Rule;
 
 /**
- * Boolean Filter
+ * BooleanScalar Filter
  *
  * @package DMS
  * @subpackage Filter
  */
-class Boolean extends BaseFilter
+class BooleanScalar extends BaseFilter
 {
     /**
      * {@inheritDoc}

--- a/src/DMS/Filter/Filters/Callback.php
+++ b/src/DMS/Filter/Filters/Callback.php
@@ -129,5 +129,4 @@ class Callback extends BaseFilter implements ObjectAwareFilter
 
         return $closure($value);
     }
-
 }

--- a/src/DMS/Filter/Filters/FloatScalar.php
+++ b/src/DMS/Filter/Filters/FloatScalar.php
@@ -5,13 +5,13 @@ namespace DMS\Filter\Filters;
 use DMS\Filter\Rules\Rule;
 
 /**
- * Float Filter
- * Converts content into a Float
+ * FloatScalar Filter
+ * Converts content into a FloatScalar
  *
  * @package DMS
  * @subpackage Filter
  */
-class Float extends BaseFilter
+class FloatScalar extends BaseFilter
 {
     /**
      * {@inheritDoc}

--- a/src/DMS/Filter/Filters/FloatScalar.php
+++ b/src/DMS/Filter/Filters/FloatScalar.php
@@ -24,5 +24,4 @@ class FloatScalar extends BaseFilter
 
         return floatval($value);
     }
-
 }

--- a/src/DMS/Filter/Filters/HtmlEntities.php
+++ b/src/DMS/Filter/Filters/HtmlEntities.php
@@ -20,5 +20,4 @@ class HtmlEntities extends BaseFilter
     {
         return htmlentities($value, $rule->flags, $rule->encoding, $rule->doubleEncode);
     }
-
 }

--- a/src/DMS/Filter/Filters/IntScalar.php
+++ b/src/DMS/Filter/Filters/IntScalar.php
@@ -5,13 +5,13 @@ namespace DMS\Filter\Filters;
 use DMS\Filter\Rules\Rule;
 
 /**
- * Int Filter
- * Converts content into an Int
+ * IntScalar Filter
+ * Converts content into an IntScalar
  *
  * @package DMS
  * @subpackage Filter
  */
-class Int extends BaseFilter
+class IntScalar extends BaseFilter
 {
     /**
      * {@inheritDoc}

--- a/src/DMS/Filter/Filters/IntScalar.php
+++ b/src/DMS/Filter/Filters/IntScalar.php
@@ -20,5 +20,4 @@ class IntScalar extends BaseFilter
     {
         return (int) ($value);
     }
-
 }

--- a/src/DMS/Filter/Filters/ObjectAwareFilter.php
+++ b/src/DMS/Filter/Filters/ObjectAwareFilter.php
@@ -26,5 +26,4 @@ interface ObjectAwareFilter
      * @return object | null
      */
     public function getCurrentObject();
-
 }

--- a/src/DMS/Filter/Filters/RegExp.php
+++ b/src/DMS/Filter/Filters/RegExp.php
@@ -48,5 +48,4 @@ class RegExp extends BaseFilter
 
         return static::$unicodeEnabled;
     }
-
 }

--- a/src/DMS/Filter/Filters/RegExp.php
+++ b/src/DMS/Filter/Filters/RegExp.php
@@ -42,11 +42,11 @@ class RegExp extends BaseFilter
      */
     public function checkUnicodeSupport()
     {
-        if (null === self::$unicodeEnabled) {
-            self::$unicodeEnabled = (@preg_match('/\pL/u', 'a')) ? true : false;
+        if (null === static::$unicodeEnabled) {
+            static::$unicodeEnabled = (@preg_match('/\pL/u', 'a')) ? true : false;
         }
 
-        return self::$unicodeEnabled;
+        return static::$unicodeEnabled;
     }
 
 }

--- a/src/DMS/Filter/Filters/StripNewlines.php
+++ b/src/DMS/Filter/Filters/StripNewlines.php
@@ -19,5 +19,4 @@ class StripNewlines extends BaseFilter
     {
         return str_replace(array("\n", "\r"), '', $value);
     }
-
 }

--- a/src/DMS/Filter/Filters/StripTags.php
+++ b/src/DMS/Filter/Filters/StripTags.php
@@ -16,7 +16,6 @@ class StripTags extends BaseFilter
      * {@inheritDoc}
      *
      * @param \DMS\Filter\Rules\StripTags $rule
-     * @param mixed $filter
      */
     public function apply(Rule $rule, $value)
     {

--- a/src/DMS/Filter/Filters/Zend.php
+++ b/src/DMS/Filter/Filters/Zend.php
@@ -55,5 +55,4 @@ class Zend extends BaseFilter
             return new $class($options);
         }
     }
-
 }

--- a/src/DMS/Filter/Mapping/ClassMetadata.php
+++ b/src/DMS/Filter/Mapping/ClassMetadata.php
@@ -75,7 +75,7 @@ class ClassMetadata implements ClassMetadataInterface
      */
     public function addPropertyRule($property, Rule $rule)
     {
-        if (!isset ($this->filteredProperties[$property])) {
+        if (!isset($this->filteredProperties[$property])) {
             $this->filteredProperties[$property] = array('rules' => array());
         }
 
@@ -101,9 +101,4 @@ class ClassMetadata implements ClassMetadataInterface
 
         return $this->reflClass;
     }
-
-
-
-
-
 }

--- a/src/DMS/Filter/Mapping/ClassMetadataFactory.php
+++ b/src/DMS/Filter/Mapping/ClassMetadataFactory.php
@@ -45,7 +45,6 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
      */
     public function getClassMetadata($class)
     {
-
         $class = ltrim($class, '\\');
 
         //Already parsed
@@ -55,10 +54,8 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
 
         //Check Cache for it
         if ($this->cache !== null && $this->cache->contains($class)) {
-
             $this->setParsedClass($class, $this->cache->fetch($class));
             return $this->getParsedClass($class);
-
         }
 
         //Parse unloaded and uncached class
@@ -153,9 +150,7 @@ class ClassMetadataFactory implements ClassMetadataFactoryInterface
     protected function loadInterfaceMetadata(ClassMetadataInterface $metadata)
     {
         foreach ($metadata->getReflectionClass()->getInterfaces() as $interface) {
-
             $metadata->mergeRules($this->getClassMetadata($interface->getName()));
-
         }
     }
 }

--- a/src/DMS/Filter/Mapping/ClassMetadataFactoryInterface.php
+++ b/src/DMS/Filter/Mapping/ClassMetadataFactoryInterface.php
@@ -4,7 +4,7 @@ namespace DMS\Filter\Mapping;
 
 /**
  * Required methods of a Metadata Factory class
- * 
+ *
  * @package DMS
  * @subpackage Filter
  */
@@ -12,7 +12,7 @@ interface ClassMetadataFactoryInterface
 {
     /**
      * Retrieve metadata for the provided class
-     * 
+     *
      * @param string $class
      * @return ClassMetadataInterface
      */

--- a/src/DMS/Filter/Mapping/Loader/AnnotationLoader.php
+++ b/src/DMS/Filter/Mapping/Loader/AnnotationLoader.php
@@ -34,7 +34,6 @@ class AnnotationLoader implements LoaderInterface
 
         //Register Filter Rules Annotation Namespace
         AnnotationRegistry::registerAutoloadNamespace('DMS\Filter\Rules', __DIR__ . '/../../../../');
-
     }
 
     /**
@@ -46,16 +45,12 @@ class AnnotationLoader implements LoaderInterface
      */
     public function loadClassMetadata(ClassMetadataInterface $metadata)
     {
-
         $reflClass = $metadata->getReflectionClass();
 
         //Iterate over properties to get annotations
         foreach ($reflClass->getProperties() as $property) {
-
             $this->readProperty($property, $metadata);
-
         }
-
     }
 
     /**
@@ -83,9 +78,6 @@ class AnnotationLoader implements LoaderInterface
 
             //Add Rule
             $metadata->addPropertyRule($property->getName(), $rule);
-
         }
-
     }
-
 }

--- a/src/DMS/Filter/ObjectWalker.php
+++ b/src/DMS/Filter/ObjectWalker.php
@@ -65,7 +65,6 @@ class ObjectWalker
      */
     public function applyFilterRule($property, Rules\Rule $filterRule)
     {
-
         if ($this->filterLoader === null) {
             throw new \UnexpectedValueException("A FilterLoader must be provided");
         }
@@ -81,7 +80,6 @@ class ObjectWalker
         $filteredValue = $filter->apply($filterRule, $value);
 
         $this->setPropertyValue($property, $filteredValue);
-
     }
 
     /**

--- a/src/DMS/Filter/Rules/Alnum.php
+++ b/src/DMS/Filter/Rules/Alnum.php
@@ -27,5 +27,4 @@ class Alnum extends RegExp
     {
         return 'allowWhitespace';
     }
-
 }

--- a/src/DMS/Filter/Rules/Alpha.php
+++ b/src/DMS/Filter/Rules/Alpha.php
@@ -27,5 +27,4 @@ class Alpha extends RegExp
     {
         return 'allowWhitespace';
     }
-
 }

--- a/src/DMS/Filter/Rules/BooleanScalar.php
+++ b/src/DMS/Filter/Rules/BooleanScalar.php
@@ -12,5 +12,4 @@ namespace DMS\Filter\Rules;
  */
 class BooleanScalar extends Rule
 {
-
 }

--- a/src/DMS/Filter/Rules/BooleanScalar.php
+++ b/src/DMS/Filter/Rules/BooleanScalar.php
@@ -3,15 +3,14 @@
 namespace DMS\Filter\Rules;
 
 /**
- * Float Rule
- * Converts content into a Float
+ * BooleanScalar Rule
  *
  * @package DMS
  * @subpackage Filter
  *
  * @Annotation
  */
-class Float extends Rule
+class BooleanScalar extends Rule
 {
 
 }

--- a/src/DMS/Filter/Rules/Digits.php
+++ b/src/DMS/Filter/Rules/Digits.php
@@ -27,5 +27,4 @@ class Digits extends RegExp
     {
         return 'allowWhitespace';
     }
-
 }

--- a/src/DMS/Filter/Rules/FloatScalar.php
+++ b/src/DMS/Filter/Rules/FloatScalar.php
@@ -3,14 +3,15 @@
 namespace DMS\Filter\Rules;
 
 /**
- * Boolean Rule
+ * FloatScalar Rule
+ * Converts content into a FloatScalar
  *
  * @package DMS
  * @subpackage Filter
  *
  * @Annotation
  */
-class Boolean extends Rule
+class FloatScalar extends Rule
 {
 
 }

--- a/src/DMS/Filter/Rules/FloatScalar.php
+++ b/src/DMS/Filter/Rules/FloatScalar.php
@@ -13,5 +13,4 @@ namespace DMS\Filter\Rules;
  */
 class FloatScalar extends Rule
 {
-
 }

--- a/src/DMS/Filter/Rules/HtmlEntities.php
+++ b/src/DMS/Filter/Rules/HtmlEntities.php
@@ -31,5 +31,4 @@ class HtmlEntities extends Rule
      * @var bool
      */
     public $doubleEncode = true;
-
 }

--- a/src/DMS/Filter/Rules/IntScalar.php
+++ b/src/DMS/Filter/Rules/IntScalar.php
@@ -3,15 +3,15 @@
 namespace DMS\Filter\Rules;
 
 /**
- * Int Rule
- * Converts content into an Int
+ * IntScalar Rule
+ * Converts content into an IntScalar
  *
  * @package DMS
  * @subpackage Filter
  *
  * @Annotation
  */
-class Int extends Rule
+class IntScalar extends Rule
 {
 
 }

--- a/src/DMS/Filter/Rules/IntScalar.php
+++ b/src/DMS/Filter/Rules/IntScalar.php
@@ -13,5 +13,4 @@ namespace DMS\Filter\Rules;
  */
 class IntScalar extends Rule
 {
-
 }

--- a/src/DMS/Filter/Rules/RegExp.php
+++ b/src/DMS/Filter/Rules/RegExp.php
@@ -27,5 +27,4 @@ class RegExp extends Rule
      * @var string
      */
     public $pattern;
-
 }

--- a/src/DMS/Filter/Rules/Rule.php
+++ b/src/DMS/Filter/Rules/Rule.php
@@ -33,7 +33,6 @@ abstract class Rule
      */
     public function __construct($options = null)
     {
-
         $result = $this->parseOptions($options);
 
         if (count($result->invalidOptions) > 0) {
@@ -101,7 +100,6 @@ abstract class Rule
     private function parseOptionsArray($options, \stdClass $result)
     {
         foreach ($options as $option => $value) {
-
             if (! property_exists($this, $option)) {
                 $result->invalidOptions[] = $option;
                 continue;

--- a/tests/DMS/Filter/Filters/AlnumTest.php
+++ b/tests/DMS/Filter/Filters/AlnumTest.php
@@ -27,11 +27,9 @@ class AlnumTest extends FilterTestCase
         $filter = new Alnum();
 
         if ($unicodeSetting !== null) {
-
             $property = new \ReflectionProperty($filter, 'unicodeEnabled');
             $property->setAccessible(true);
             $property->setValue($filter, $unicodeSetting);
-
         }
 
         $result = $filter->apply($rule, $value);

--- a/tests/DMS/Filter/Filters/AlphaTest.php
+++ b/tests/DMS/Filter/Filters/AlphaTest.php
@@ -27,11 +27,9 @@ class AlphaTest extends FilterTestCase
         $filter = new Alpha();
 
         if ($unicodeSetting !== null) {
-
             $property = new \ReflectionProperty($filter, 'unicodeEnabled');
             $property->setAccessible(true);
             $property->setValue($filter, $unicodeSetting);
-
         }
 
         $result = $filter->apply($rule, $value);

--- a/tests/DMS/Filter/Filters/BooleanTest.php
+++ b/tests/DMS/Filter/Filters/BooleanTest.php
@@ -36,7 +36,7 @@ class BooleanTest extends FilterTestCase
         return array(
             array(null, "My Text", true),
             array(null, "", false),
-            array(null, NULL, false),
+            array(null, null, false),
             array(null, 21.9, true),
             array(null, 21, true),
             array(null, 0, false),

--- a/tests/DMS/Filter/Filters/BooleanTest.php
+++ b/tests/DMS/Filter/Filters/BooleanTest.php
@@ -3,7 +3,7 @@
 namespace DMS\Filter\Filters;
 
 use DMS\Tests\FilterTestCase;
-use DMS\Filter\Rules\Boolean as BooleanRule;
+use DMS\Filter\Rules\BooleanScalar as BooleanRule;
 
 class BooleanTest extends FilterTestCase
 {
@@ -24,7 +24,7 @@ class BooleanTest extends FilterTestCase
     public function testRule($options, $value, $expectedResult)
     {
         $rule = new BooleanRule($options);
-        $filter = new Boolean();
+        $filter = new BooleanScalar();
 
         $result = $filter->apply($rule, $value);
 

--- a/tests/DMS/Filter/Filters/DigitsTest.php
+++ b/tests/DMS/Filter/Filters/DigitsTest.php
@@ -27,11 +27,9 @@ class DigitsTest extends FilterTestCase
         $filter = new Digits();
 
         if ($unicodeSetting !== null) {
-
             $property = new \ReflectionProperty($filter, 'unicodeEnabled');
             $property->setAccessible(true);
             $property->setValue($filter, $unicodeSetting);
-
         }
 
         $result = $filter->apply($rule, $value);

--- a/tests/DMS/Filter/Filters/FloatTest.php
+++ b/tests/DMS/Filter/Filters/FloatTest.php
@@ -3,7 +3,7 @@
 namespace DMS\Filter\Filters;
 
 use DMS\Tests\FilterTestCase;
-use DMS\Filter\Rules\Float as FloatRule;
+use DMS\Filter\Rules\FloatScalar as FloatRule;
 
 class FloatTest extends FilterTestCase
 {
@@ -24,7 +24,7 @@ class FloatTest extends FilterTestCase
     public function testRule($options, $value, $expectedResult)
     {
         $rule   = new FloatRule($options);
-        $filter = new Float();
+        $filter = new FloatScalar();
 
         $result = $filter->apply($rule, $value);
 

--- a/tests/DMS/Filter/Filters/IntTest.php
+++ b/tests/DMS/Filter/Filters/IntTest.php
@@ -3,7 +3,7 @@
 namespace DMS\Filter\Filters;
 
 use DMS\Tests\FilterTestCase;
-use DMS\Filter\Rules\Int as IntRule;
+use DMS\Filter\Rules\IntScalar as IntRule;
 
 class IntTest extends FilterTestCase
 {
@@ -24,7 +24,7 @@ class IntTest extends FilterTestCase
     public function testRule($options, $value, $expectedResult)
     {
         $rule   = new IntRule($options);
-        $filter = new Int();
+        $filter = new IntScalar();
 
         $result = $filter->apply($rule, $value);
 

--- a/tests/DMS/Filter/Filters/ToLowerTest.php
+++ b/tests/DMS/Filter/Filters/ToLowerTest.php
@@ -24,7 +24,7 @@ class ToLowerTest extends FilterTestCase
     public function testRule($options, $value, $expectedResult, $useEncoding)
     {
         if ($useEncoding && !function_exists('mb_strtolower')) {
-            $this->markTestSkipped ('mbstring extension not enabled');
+            $this->markTestSkipped('mbstring extension not enabled');
         }
 
         $rule   = new ToLowerRule($options);
@@ -40,8 +40,8 @@ class ToLowerTest extends FilterTestCase
      */
     public function testInvalidEncoding()
     {
-        if ( ! function_exists('mb_strtolower')) {
-            $this->markTestSkipped ('mbstring extension not enabled');
+        if (! function_exists('mb_strtolower')) {
+            $this->markTestSkipped('mbstring extension not enabled');
         }
 
         $rule = new ToLowerRule(array('encoding' => 'invalid'));

--- a/tests/DMS/Filter/Filters/ToUpperTest.php
+++ b/tests/DMS/Filter/Filters/ToUpperTest.php
@@ -24,7 +24,7 @@ class ToUpperTest extends FilterTestCase
     public function testRule($options, $value, $expectedResult, $useEncoding)
     {
         if ($useEncoding && !function_exists('mb_strtoupper')) {
-            $this->markTestSkipped ('mbstring extension not enabled');
+            $this->markTestSkipped('mbstring extension not enabled');
         }
 
         $rule   = new ToUpperRule($options);
@@ -40,8 +40,8 @@ class ToUpperTest extends FilterTestCase
      */
     public function testInvalidEncoding()
     {
-        if ( ! function_exists('mb_strtoupper')) {
-            $this->markTestSkipped ('mbstring extension not enabled');
+        if (! function_exists('mb_strtoupper')) {
+            $this->markTestSkipped('mbstring extension not enabled');
         }
 
         $rule   = new ToUpperRule(array('encoding' => 'invalid'));

--- a/tests/DMS/Filter/Mapping/ClassMetadataFactoryTest.php
+++ b/tests/DMS/Filter/Mapping/ClassMetadataFactoryTest.php
@@ -39,7 +39,6 @@ class ClassMetadataFactoryTest extends FilterTestCase
         $metadataReparsed = $this->factory->getClassMetadata('DMS\Tests\Dummy\Classes\AnnotatedClass');
 
         $this->assertSame($metadata, $metadataReparsed);
-
     }
 
     public function testCachedMetadataFromFactory()
@@ -59,5 +58,3 @@ class ClassMetadataFactoryTest extends FilterTestCase
         $this->assertEquals($metadata, $metadataCached);
     }
 }
-
-?>

--- a/tests/DMS/Filter/Rules/RuleTest.php
+++ b/tests/DMS/Filter/Rules/RuleTest.php
@@ -92,11 +92,9 @@ class RuleTest extends FilterTestCase
         try {
             $rule = new MultipleOptionsRule(array('invalid' => 'option'));
         } catch (InvalidOptionsException $e) {
-
             $this->assertInternalType('array', $e->getOptions());
 
             $this->assertContains('invalid', $e->getOptions());
-
         }
     }
 }

--- a/tests/DMS/Tests/Dummy/Classes/AnnotatedInterface.php
+++ b/tests/DMS/Tests/Dummy/Classes/AnnotatedInterface.php
@@ -4,5 +4,4 @@ namespace DMS\Tests\Dummy\Classes;
 
 interface AnnotatedInterface
 {
-
 }

--- a/tests/DMS/Tests/Dummy/Classes/ChildAnnotatedClass.php
+++ b/tests/DMS/Tests/Dummy/Classes/ChildAnnotatedClass.php
@@ -12,5 +12,4 @@ class ChildAnnotatedClass extends AnnotatedClass implements AnnotatedInterface
      * @var string
      */
     public $surname;
-
 }

--- a/tests/DMS/Tests/Dummy/Rules/DefaultOptionRule.php
+++ b/tests/DMS/Tests/Dummy/Rules/DefaultOptionRule.php
@@ -17,5 +17,4 @@ class DefaultOptionRule extends Rule
     {
         return 'config';
     }
-
 }

--- a/tests/DMS/Tests/Dummy/Rules/InvalidDefaultOptionRule.php
+++ b/tests/DMS/Tests/Dummy/Rules/InvalidDefaultOptionRule.php
@@ -17,5 +17,4 @@ class InvalidDefaultOptionRule extends Rule
     {
         return 'path';
     }
-
 }

--- a/tests/DMS/Tests/Dummy/Rules/MultipleOptionsRule.php
+++ b/tests/DMS/Tests/Dummy/Rules/MultipleOptionsRule.php
@@ -15,6 +15,4 @@ class MultipleOptionsRule extends Rule
     {
         return $value;
     }
-
-
 }

--- a/tests/DMS/Tests/Dummy/Rules/NoOptionsRule.php
+++ b/tests/DMS/Tests/Dummy/Rules/NoOptionsRule.php
@@ -10,5 +10,4 @@ class NoOptionsRule extends Rule
     {
         return $value;
     }
-
 }

--- a/tests/DMS/Tests/Dummy/Rules/RequiredOptionsRule.php
+++ b/tests/DMS/Tests/Dummy/Rules/RequiredOptionsRule.php
@@ -24,5 +24,4 @@ class RequiredOptionsRule extends Rule
     {
         return array('config', 'path');
     }
-
 }


### PR DESCRIPTION
- renamed classes that use Scalar names to append `Scalar`, so we avoid reserved keywords
- also renamed boolena even if its not a problem for consistency
- changed use of `self` in RegExp Filter to `static` due to handling changes (need to track down this change)

This will break BC so scheduling a new major release.