### PR TITLE
modified ObjectWalker to handle private properties in parent classes

### DIFF
--- a/src/DMS/Filter/ObjectWalker.php
+++ b/src/DMS/Filter/ObjectWalker.php
@@ -114,9 +114,24 @@ class ObjectWalker
      */
     private function getAccessibleReflectionProperty($propertyName)
     {
-        $property = $this->reflClass->getProperty($propertyName);
+        $property = $this->getReflectionProperty($this->reflClass, $propertyName);
         $property->setAccessible(true);
 
         return $property;
+    }
+
+    private function getReflectionProperty($class, $name)
+    {
+        try {
+            return $class->getProperty($name);
+        }
+        catch (\ReflectionException $e) {
+            $parent = $class->getParentClass();
+            if (null === $parent) {
+                throw new \Exception(sprintf('property not exists %s', $name));
+            }
+
+            return $this->getReflectionProperty($parent, $name);
+        }
     }
 }

--- a/tests/DMS/Filter/FilterTest.php
+++ b/tests/DMS/Filter/FilterTest.php
@@ -118,4 +118,14 @@ class FilterTest extends FilterTestCase
     {
         $this->assertInstanceOf('DMS\Filter\Mapping\ClassMetadataFactory', $this->filter->getMetadataFactory());
     }
+
+    public function testFilterPrivate()
+    {
+        $class = new Dummy\Classes\AnotherChildAnnotatedClass();
+        $class->setPrivateProperty('  needs to be trimmed   ');
+
+        $this->filter->filterEntity($class);
+
+        $this->assertEquals($class->getPrivateProperty(), 'needs to be trimmed');
+    }
 }

--- a/tests/DMS/Tests/Dummy/Classes/AnnotatedClass.php
+++ b/tests/DMS/Tests/Dummy/Classes/AnnotatedClass.php
@@ -52,6 +52,12 @@ class AnnotatedClass
     public $zendalternate;
 
     /**
+     * @var string
+     * @Filter\Trim
+     */
+    private $privateProperty;
+
+    /**
      * @param $value
      * @return string
      */
@@ -67,5 +73,15 @@ class AnnotatedClass
     public static function anotherCallback($value)
     {
         return 'called_back';
+    }
+
+    public function setPrivateProperty($value)
+    {
+        $this->privateProperty = $value;
+    }
+
+    public function getPrivateProperty()
+    {
+        return $this->privateProperty;
     }
 }

--- a/tests/DMS/Tests/Dummy/Classes/AnotherChildAnnotatedClass.php
+++ b/tests/DMS/Tests/Dummy/Classes/AnotherChildAnnotatedClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DMS\Tests\Dummy\Classes;
+
+use DMS\Filter\Rules as Filter;
+
+class AnotherChildAnnotatedClass extends ChildAnnotatedClass
+{
+}


### PR DESCRIPTION
ObjectWalker can handle private properties in parent classes with this modification. Tested. Please merge it into master.