### PR TITLE
PHP 8 fixes

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,30 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         verbose="true"
-         beStrictAboutOutputDuringTests="true"
-         beStrictAboutTestsThatDoNotTestAnything="true"
-         beStrictAboutTodoAnnotatedTests="true"
-         beStrictAboutChangesToGlobalState="true"
->
-    <testsuites>
-        <testsuite name="DMS Filter Suite">
-            <directory>tests/DMS</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/DMS</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-html" target="tests/_reports/coverage/" lowUpperBound="35" highLowerBound="70"/>
-        <log type="testdox-text" target="tests/_reports/testdox/tests.txt"/>
-        <log type="testdox-html" target="tests/_reports/testdox/tests.html"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" verbose="true" beStrictAboutOutputDuringTests="true" beStrictAboutTestsThatDoNotTestAnything="true" beStrictAboutTodoAnnotatedTests="true" beStrictAboutChangesToGlobalState="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">src/DMS</directory>
+    </include>
+    <report>
+      <html outputDirectory="tests/_reports/coverage/" lowUpperBound="35" highLowerBound="70"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="DMS Filter Suite">
+      <directory>tests/DMS</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <testdoxText outputFile="tests/_reports/testdox/tests.txt"/>
+    <testdoxHtml outputFile="tests/_reports/testdox/tests.html"/>
+  </logging>
 </phpunit>

--- a/src/DMS/Filter/Filters/Laminas.php
+++ b/src/DMS/Filter/Filters/Laminas.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace DMS\Filter\Filters;
+
+use DMS\Filter\Exception\InvalidZendFilterException;
+use DMS\Filter\FilterInterface;
+use DMS\Filter\Rules\Rule;
+use DMS\Filter\Rules\Laminas as LaminasRule;
+use ReflectionException;
+use ReflectionMethod;
+
+use function class_exists;
+use function sprintf;
+use function strpos;
+
+/**
+ * Laminas Filter
+ *
+ * Instantiates and runs Laminas Filters (from ZF2)
+ */
+class Laminas extends BaseFilter
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param LaminasRule $rule
+     */
+    public function apply(Rule $rule, $value)
+    {
+        return $this->getLaminasInstance($rule->class, $rule->laminasOptions)->filter($value);
+    }
+
+    /**
+     * Instantiates a configured Laminas Filter, if it exists
+     *
+     * @param mixed[] $options
+     *
+     * @return FilterInterface|object
+     *
+     * @throws InvalidZendFilterException
+     */
+    public function getLaminasInstance(string $class, array $options): object
+    {
+        if (strpos($class, 'Laminas\Filter') === false) {
+            $class = 'Laminas\Filter\\' . $class;
+        }
+
+        if (! class_exists($class)) {
+            throw new InvalidZendFilterException(sprintf('Could not find or autoload: %s', $class));
+        }
+
+        try {
+            new ReflectionMethod($class, 'setOptions');
+
+            $filter = new $class();
+            $filter->setOptions($options);
+
+            return $filter;
+        } catch (ReflectionException $e) {
+            return new $class($options);
+        }
+    }
+}

--- a/src/DMS/Filter/Filters/PregReplace.php
+++ b/src/DMS/Filter/Filters/PregReplace.php
@@ -20,6 +20,6 @@ class PregReplace extends BaseFilter
      */
     public function apply(Rule $rule, $value)
     {
-        return preg_replace($rule->regexp, $rule->replacement, $value);
+        return is_string($value) ? preg_replace($rule->regexp, $rule->replacement, $value) : $value;
     }
 }

--- a/src/DMS/Filter/Filters/RegExp.php
+++ b/src/DMS/Filter/Filters/RegExp.php
@@ -40,7 +40,7 @@ class RegExp extends BaseFilter
      */
     public function checkUnicodeSupport(): bool
     {
-        if (static::$unicodeEnabled === null) {
+        if (!isset(static::$unicodeEnabled)) {
             //phpcs:disable SlevomatCodingStandard.ControlStructures.UselessTernaryOperator.UselessTernaryOperator
             static::$unicodeEnabled = @preg_match('/\pL/u', 'a') ? true : false;
         }

--- a/src/DMS/Filter/Filters/RegExp.php
+++ b/src/DMS/Filter/Filters/RegExp.php
@@ -32,7 +32,7 @@ class RegExp extends BaseFilter
             ? $rule->unicodePattern
             : $rule->pattern;
 
-        return preg_replace($pattern, '', $value);
+        return is_string($value) ? preg_replace($pattern, '', $value) : $value;
     }
 
     /**

--- a/src/DMS/Filter/Filters/StripNewlines.php
+++ b/src/DMS/Filter/Filters/StripNewlines.php
@@ -17,6 +17,6 @@ class StripNewlines extends BaseFilter
      */
     public function apply(Rule $rule, $value)
     {
-        return str_replace(["\n", "\r"], '', $value);
+        return is_string($value) ? str_replace(["\n", "\r"], '', $value) : $value;
     }
 }

--- a/src/DMS/Filter/Filters/StripTags.php
+++ b/src/DMS/Filter/Filters/StripTags.php
@@ -19,6 +19,6 @@ class StripTags extends BaseFilter
      */
     public function apply(Rule $rule, $value)
     {
-        return strip_tags($value, $rule->allowed);
+        return is_string($value) ? strip_tags($value, $rule->allowed) : $value;
     }
 }

--- a/src/DMS/Filter/Filters/Trim.php
+++ b/src/DMS/Filter/Filters/Trim.php
@@ -19,6 +19,10 @@ class Trim extends BaseFilter
      */
     public function apply(Rule $rule, $value)
     {
+        if (!is_string($value)) {
+            return $value;
+        }
+
         //trim() only operates in default mode
         //if no second argument is passed, it
         //cannot be passed as null

--- a/src/DMS/Filter/Rules/Laminas.php
+++ b/src/DMS/Filter/Rules/Laminas.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace DMS\Filter\Rules;
+
+/**
+ * Laminas Rule
+ *
+ * Allows the use for Laminas Filters
+ *
+ * @Annotation
+ */
+class Laminas extends Rule
+{
+    /**
+     * Laminas\Filter class, can be either a FQN or just Boolean for example
+     */
+    public string $class;
+
+    /**
+     * Array of options to be passed into the Laminas Filter
+     *
+     * @var mixed[]
+     */
+    public array $laminasOptions = [];
+
+    public function getDefaultOption(): ?string
+    {
+        return 'class';
+    }
+}

--- a/tests/DMS/Filter/Filters/AlnumTest.php
+++ b/tests/DMS/Filter/Filters/AlnumTest.php
@@ -54,6 +54,7 @@ class AlnumTest extends FilterTestCase
             [true, "Helgi Þormar Þorbjörnsson", "Helgi ormar orbjrnsson", false],
             [true, "Helgi Þormar!@#$&*( )(*&%$#@Þorbjörnsson", "Helgi Þormar Þorbjörnsson", true],
             [true, "Helgi Þormar!@#$&*( )(*&%$#@Þorbjörnsson", "Helgi ormar orbjrnsson", false],
+            [true, null, null, false],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/AlphaTest.php
+++ b/tests/DMS/Filter/Filters/AlphaTest.php
@@ -52,6 +52,7 @@ class AlphaTest extends FilterTestCase
             [true, "Helgi Þormar Þorbjörnsson", "Helgi ormar orbjrnsson", false],
             [true, "Helgi Þormar!@#$&*( )(*&%$#@Þorbjörnsson", "Helgi Þormar Þorbjörnsson", true],
             [true, "Helgi Þormar!@#$&*( )(*&%$#@Þorbjörnsson", "Helgi ormar orbjrnsson", false],
+            [true, null, null, false],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/IntTest.php
+++ b/tests/DMS/Filter/Filters/IntTest.php
@@ -34,6 +34,7 @@ class IntTest extends FilterTestCase
             [null, "21.2", 21],
             [null, "21.9", 21],
             [null, 21.9, 21],
+            [null, null, null],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/LaminasTest.php
+++ b/tests/DMS/Filter/Filters/LaminasTest.php
@@ -1,0 +1,46 @@
+<?php
+
+
+namespace DMS\Filter\Filters;
+
+use DMS\Filter\Exception\InvalidZendFilterException;
+use DMS\Filter\Rules\Laminas as LaminasRule;
+use DMS\Tests\FilterTestCase;
+
+class LaminasTest extends FilterTestCase
+{
+
+    public function testFilterShortname(): void
+    {
+        $rule = $this->buildRule('Boolean', ['casting' => false]);
+        $filter = new Laminas();
+        $filter->apply($rule, '0');
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testFilterFullname(): void
+    {
+        $rule = $this->buildRule('Laminas\Filter\Boolean', ['casting' => false]);
+        $filter = new Laminas();
+        $filter->apply($rule, '0');
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testInvalidFilter(): void
+    {
+        $this->expectException(InvalidZendFilterException::class);
+        $rule = $this->buildRule('MissingFilter');
+        $filter = new Laminas();
+        $filter->apply($rule, '0');
+    }
+
+    protected function buildRule($class, $options = []): LaminasRule
+    {
+        return new LaminasRule(
+            [
+                'class'   => $class,
+                'laminasOptions' => $options,
+            ]
+        );
+    }
+}

--- a/tests/DMS/Filter/Filters/PregReplaceTest.php
+++ b/tests/DMS/Filter/Filters/PregReplaceTest.php
@@ -32,6 +32,7 @@ class PregReplaceTest extends FilterTestCase
             [['regexp' => '/(old)/', 'replacement' => 'new'], "the crazy old fox", "the crazy new fox"],
             [['regexp' => '/([0-9]*)/'], "this is day 21", "this is day "],
             [['regexp' => '/(style=\"[^\"]*\")/'], "<table style=\"width: 23px\" class=\"myclass\">", "<table  class=\"myclass\">"],
+            [['regexp' => '/(style=\"[^\"]*\")/'], null, null],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/StripNewlinesTest.php
+++ b/tests/DMS/Filter/Filters/StripNewlinesTest.php
@@ -35,6 +35,7 @@ class StripNewlinesTest extends FilterTestCase
                 null, "My
 Text", "MyText"
             ],
+            [null, null, null],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/StripTagsTest.php
+++ b/tests/DMS/Filter/Filters/StripTagsTest.php
@@ -33,6 +33,7 @@ class StripTagsTest extends FilterTestCase
             [[], "<b>in this case a < 2 a > 3;</b>", "in this case a < 2 a > 3;"],
             [['allowed' => "<p>"], "<b><p>my text</p></b>", "<p>my text</p>"],
             ["<p>", "<b><p>my text</p></b>", "<p>my text</p>"],
+            [[], null, null],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/ToLowerTest.php
+++ b/tests/DMS/Filter/Filters/ToLowerTest.php
@@ -53,6 +53,7 @@ class ToLowerTest extends FilterTestCase
             ['utf-8', "MY Á TEXT", "my á text", true],
             [[], "MY TEXT", "my text", false],
             [[], "MY TEXT", "my text", false],
+            [[], null, null, false],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/ToUpperTest.php
+++ b/tests/DMS/Filter/Filters/ToUpperTest.php
@@ -53,6 +53,7 @@ class ToUpperTest extends FilterTestCase
             ['utf-8', "my á text", "MY Á TEXT", true],
             [[], "my text", "MY TEXT", false],
             [[], "my text", "MY TEXT", false],
+            [[], null, null, false],
         ];
     }
 }

--- a/tests/DMS/Filter/Filters/TrimTest.php
+++ b/tests/DMS/Filter/Filters/TrimTest.php
@@ -34,6 +34,7 @@ class TrimTest extends FilterTestCase
             [['charlist' => "\\"], "\my text", "my text"],
             ["\\", "\my text", "my text"],
             ["x", "xmy textx", "my text"],
+            [[], null, null],
         ];
     }
 }


### PR DESCRIPTION
I'm in the process of upgrading our app to PHP8 and ran into a few issues with the DMS Filter bundle. I've written some fixes that work for my use case, I thought I would raise a PR for them in case it would be useful for them to be incorporated?

The following are changed:

**Updated filters to support nullable fields**

With PHP8 functions such as strip_tags() can throw when a non-string value is provided. I've wrapped the affected function calls in is_string() checks to provide a graceful fallback, and updated the unit tests accordingly. This has allowed me to continue using the filters on fields that are nullable.

**Fixed a crash on the RegExp filter**

When the unicodeEnabled static property is not set against the RegExp class, the existing null check in the checkUnicodeSupport method would result in an Error being thrown. I've changed the null check for an isset() call to resolve this.

**Added Laminas rule/filter**

This is to support the move from Zend to Laminas. I've not made any changes to the existing Zend classes for this. If there is another, better solution for this I'm happy to remove the new classes, or indeed make changes to any of the above. 

Thanks, Kieran